### PR TITLE
Register component in uppercase

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,7 @@ exports.install = function (Vue, options = {}) {
   Vue.chartist = require('chartist')
   Vue.prototype.$chartist = require('chartist')
 
-  Vue.component('chartist', {
+  Vue.component('Chartist', {
     render (h) {
       return h('div', {
         ref: 'chart',


### PR DESCRIPTION
New vue eslint rule recommend to use PascalCase components. ([link](https://github.com/vuejs/eslint-plugin-vue/blob/master/docs/rules/component-name-in-template-casing.md#enforce-specific-casing-for-the-component-naming-style-in-template-vuecomponent-name-in-template-casing))

Registering component with uppercase will allow both `<chartist />` and `<Chartist />`
https://vuejs.org/v2/guide/components-registration.html#Name-Casing